### PR TITLE
Initialize Next.js blog scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+out/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # gpt-test
+
+This repository contains a minimal Next.js blog configured for deployment to GitHub Pages.
+
+## Getting Started
+
+Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+### Development
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Build and Export
+
+Build the project and export static files:
+
+```bash
+npm run build
+```
+
+The static site will be generated in the `out/` directory. Deploy the contents of this directory to the `gh-pages` branch or a folder configured for GitHub Pages.
+
+The `next.config.js` file sets `basePath` and `assetPrefix` for production so that the site works when served from the `/gpt-test` subpath on GitHub Pages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+const isProd = process.env.NODE_ENV === 'production';
+const repo = 'gpt-test';
+
+module.exports = {
+  output: 'export',
+  basePath: isProd ? `/${repo}` : '',
+  assetPrefix: isProd ? `/${repo}/` : '',
+  trailingSlash: true,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gpt-test-blog",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to my Next.js Blog</h1>
+      <p>This blog is deployed on GitHub Pages.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add initial Next.js blog setup
- document how to run and export to GitHub Pages
- ignore build and dependency artifacts

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run build` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545f1a3d3483278409ec010d3bbd82